### PR TITLE
Missing cstdint on mbc.h

### DIFF
--- a/include/mbc.h
+++ b/include/mbc.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 
 class MBC {


### PR DESCRIPTION
cstdint needs to be included in order to access fixed-sized integral types: https://en.cppreference.com/w/cpp/header/cstdint.html

Some compilers fail to build without it (gcc 14.3 for example)